### PR TITLE
explicitly add subplatform call for firmata usage

### DIFF
--- a/GroveStarterKit/grove-button.js
+++ b/GroveStarterKit/grove-button.js
@@ -13,6 +13,10 @@ module.exports = function(RED) {
         this.pin = n.pin;
         this.mode = n.mode;
         this.interval = n.interval
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.sensor = new groveSensor.GroveButton(parseInt(this.pin) + parseInt(this.platform));
         this.board = m.getPlatformName();
         this.status({});

--- a/GroveStarterKit/grove-led.js
+++ b/GroveStarterKit/grove-led.js
@@ -13,6 +13,10 @@ module.exports = function(RED) {
         this.pin = n.pin;
         this.mode = n.mode;
         this.interval = n.interval
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.sensor = new groveSensor.GroveLed(parseInt(this.pin) + parseInt(this.platform));
         this.status({});
 

--- a/GroveStarterKit/grove-light.js
+++ b/GroveStarterKit/grove-light.js
@@ -12,7 +12,11 @@ module.exports = function(RED){
         this.platform = n.platform;
         this.pin = n.pin;
         this.unit = n.unit;
-        this.interval = n.interval
+        this.interval = n.interval;
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.sensor = new groveSensor.GroveLight(parseInt(this.pin) + parseInt(this.platform));
         this.status({});
         

--- a/GroveStarterKit/grove-relay.js
+++ b/GroveStarterKit/grove-relay.js
@@ -12,6 +12,10 @@ module.exports = function(RED) {
 	this.platform = n.platform;
         this.pin = n.pin;
         this.interval = n.interval;
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.relay = new upmRelay.GroveRelay(parseInt(this.pin) + parseInt(this.platform));
         this.board = m.getPlatformName();
         this.status({});

--- a/GroveStarterKit/grove-rgb-lcd.js
+++ b/GroveStarterKit/grove-rgb-lcd.js
@@ -15,6 +15,10 @@ module.exports = function(RED) {
         this.b = parseInt(n.b);
         this.row = parseInt(n.row);
         this.column = parseInt(n.column);
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.sensor = new LCD.Jhd1313m1 (parseInt(this.platform), 0x3E, 0x62);
         this.board = m.getPlatformName();
         this.status({});

--- a/GroveStarterKit/grove-rotary.js
+++ b/GroveStarterKit/grove-rotary.js
@@ -12,7 +12,11 @@ module.exports = function(RED){
         this.platform = n.platform;
         this.pin = n.pin;
         this.unit = n.unit;
-        this.interval = n.interval
+        this.interval = n.interval;
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.sensor = new groveSensor.GroveRotary(parseInt(this.pin) + parseInt(this.platform));
         this.status({});
         

--- a/GroveStarterKit/grove-servo.js
+++ b/GroveStarterKit/grove-servo.js
@@ -12,6 +12,10 @@ module.exports = function(RED) {
         this.platform = n.platform;
         this.pin = n.pin;
         this.angle = parseInt(n.angle);
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.servo = new servoModule.ES08A(parseInt(this.pin) + parseInt(this.platform));
         this.status({});
 

--- a/GroveStarterKit/grove-sound.js
+++ b/GroveStarterKit/grove-sound.js
@@ -12,7 +12,11 @@ module.exports = function(RED){
         this.platform = n.platform;
         this.pin = n.pin;
         this.unit = n.unit;
-        this.interval = n.interval
+        this.interval = n.interval;
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.sensor = new m.Aio(parseInt(this.pin) + parseInt(this.platform));
         this.status({});
 

--- a/GroveStarterKit/grove-temperature.js
+++ b/GroveStarterKit/grove-temperature.js
@@ -12,7 +12,11 @@ module.exports = function(RED){
         this.platform = n.platform;
         this.pin = n.pin;
         this.unit = n.unit;
-        this.interval = n.interval
+        this.interval = n.interval;
+        if(parseInt(this.platform) == 512) {
+            //explicitly add the FIRMATA subplatform for MRAA
+            m.addSubplatform(m.GENERIC_FIRMATA, "/dev/ttyACM0");
+        }
         this.sensor = new groveSensor.GroveTemp(parseInt(this.pin) + parseInt(this.platform));
         this.status({});
 


### PR DESCRIPTION
On Ubuntu platform Firmata platform is not detected
by mraa by default, this change is to check if the selected
platform is Firmata and explicitly add the subplatform.
Even if it is already added at some point, an additional
call will not cause any issues

Signed-off-by: Huzefa N K <huzefank@gmail.com>